### PR TITLE
Refactor backend CSV fields to kidou/zaiku naming

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -110,7 +110,7 @@ def process_task(task_id: str, csv_path: Path, pdf_paths: List[Path]) -> None:
             if tokens:
                 state.totals.tokens += len(tokens)
             for token in tokens:
-                hinban_matches, spec_matches = matcher.match_token(token)
+                hinban_matches, kidou_matches = matcher.match_token(token)
                 matched = False
                 for row in hinban_matches:
                     results.append(
@@ -120,13 +120,13 @@ def process_task(task_id: str, csv_path: Path, pdf_paths: List[Path]) -> None:
                             token=token,
                             matched_type="hinban",
                             matched_hinban=row.hinban,
-                            zaiko=row.zaiko,
+                            zaiku=row.zaiku,
                         )
                     )
                     state.totals.hit_hinban += 1
                     matched = True
-                if spec_matches:
-                    for row in spec_matches:
+                if kidou_matches:
+                    for row in kidou_matches:
                         results.append(
                             ResultRow(
                                 pdf_name=pdf_name,
@@ -134,7 +134,7 @@ def process_task(task_id: str, csv_path: Path, pdf_paths: List[Path]) -> None:
                                 token=token,
                                 matched_type="spec",
                                 matched_hinban=row.hinban,
-                                zaiko=row.zaiko,
+                                zaiku=row.zaiku,
                             )
                         )
                         state.totals.hit_spec += 1
@@ -165,9 +165,9 @@ def process_task(task_id: str, csv_path: Path, pdf_paths: List[Path]) -> None:
 
     write_csv(
         results_csv,
-        ["pdf_name", "page", "token", "matched_type", "matched_hinban", "zaiko"],
+        ["pdf_name", "page", "token", "matched_type", "matched_hinban", "zaiku"],
         (
-            [r.pdf_name, r.page, r.token, r.matched_type, r.matched_hinban, r.zaiko or ""]
+            [r.pdf_name, r.page, r.token, r.matched_type, r.matched_hinban, r.zaiku or ""]
             for r in results
         ),
     )

--- a/backend/app/match.py
+++ b/backend/app/match.py
@@ -15,48 +15,48 @@ logger = logging.getLogger(__name__)
 @dataclass
 class MatchRow:
     hinban: str
-    spec: str
-    zaiko: str | None = None
+    kidou: str
+    zaiku: str | None = None
 
 
 class DatabaseMatcher:
     def __init__(self, csv_path: Path) -> None:
         self.csv_path = csv_path
         self.hinban_map: Dict[str, MatchRow] = {}
-        self.spec_map: Dict[str, List[MatchRow]] = {}
+        self.kidou_map: Dict[str, List[MatchRow]] = {}
         self._load()
 
     def _load(self) -> None:
         df = pd.read_csv(self.csv_path)
-        if "hinban" not in df.columns or "spec" not in df.columns:
-            raise ValueError("CSVに 'hinban' と 'spec' 列が必要です。ファイルを確認してください。")
-        zaiko_exists = "zaiko" in df.columns
+        if "hinban" not in df.columns or "kidou" not in df.columns:
+            raise ValueError("CSVに 'hinban' と 'kidou' 列が必要です。ファイルを確認してください。")
+        zaiku_exists = "zaiku" in df.columns
         for _, row in df.iterrows():
             hinban = normalize_text(str(row.get("hinban", "")))
-            spec = normalize_text(str(row.get("spec", "")))
-            zaiko = str(row.get("zaiko")) if zaiko_exists else None
-            match_row = MatchRow(hinban=hinban, spec=spec, zaiko=zaiko)
+            kidou = normalize_text(str(row.get("kidou", "")))
+            zaiku = str(row.get("zaiku")) if zaiku_exists else None
+            match_row = MatchRow(hinban=hinban, kidou=kidou, zaiku=zaiku)
             if hinban:
                 self.hinban_map[hinban] = match_row
-            for token in extract_tokens(spec):
-                self.spec_map.setdefault(token, []).append(match_row)
+            for token in extract_tokens(kidou):
+                self.kidou_map.setdefault(token, []).append(match_row)
 
     def match_token(self, token: str) -> tuple[List[MatchRow], List[MatchRow]]:
         hinban_matches: List[MatchRow] = []
-        spec_matches: List[MatchRow] = []
+        kidou_matches: List[MatchRow] = []
         normalized = normalize_text(token)
         row = self.hinban_map.get(normalized)
         if row:
             hinban_matches.append(row)
-        spec_matches = self.spec_map.get(normalized, [])
-        return hinban_matches, spec_matches
+        kidou_matches = self.kidou_map.get(normalized, [])
+        return hinban_matches, kidou_matches
 
     def retry(self, token: str) -> List[str]:
         normalized = normalize_text(token)
         candidates = []
         if normalized in self.hinban_map:
             candidates.append(self.hinban_map[normalized].hinban)
-        candidates.extend({row.hinban for row in self.spec_map.get(normalized, [])})
+        candidates.extend({row.hinban for row in self.kidou_map.get(normalized, [])})
         return sorted(set(candidates))
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -29,7 +29,7 @@ class ResultRow(BaseModel):
     token: str
     matched_type: str
     matched_hinban: str
-    zaiko: Optional[str] = None
+    zaiku: Optional[str] = None
 
 
 class FailureRow(BaseModel):

--- a/backend/app/sample_db.csv
+++ b/backend/app/sample_db.csv
@@ -1,4 +1,4 @@
-hinban,spec,zaiko
+hinban,kidou,zaiku
 AB-1234,Type-A Spec 400V,25
 ZX-9900,High-Speed Motor 220V,5
 MN-450X,Precision-Lens Spec,0


### PR DESCRIPTION
## Summary
- update matcher loading logic to use kidou and zaiku columns when reading CSV data
- align result serialization and CSV exports with the new kidou/zaiku field names
- refresh the bundled sample database headers to match the renamed columns

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68e66f9b7d5c8330a4cd1c7d5e891893