### PR TITLE
Handle non UTF-8 CSV files

### DIFF
--- a/backend/app/match.py
+++ b/backend/app/match.py
@@ -27,7 +27,10 @@ class DatabaseMatcher:
         self._load()
 
     def _load(self) -> None:
-        df = pd.read_csv(self.csv_path)
+        try:
+            df = pd.read_csv(self.csv_path)
+        except UnicodeDecodeError:
+            df = pd.read_csv(self.csv_path, encoding="cp932")
         if "hinban" not in df.columns or "kidou" not in df.columns:
             raise ValueError("CSVに 'hinban' と 'kidou' 列が必要です。ファイルを確認してください。")
         zaiku_exists = "zaiku" in df.columns


### PR DESCRIPTION
## Summary
- add a fallback encoding when loading the CSV in DatabaseMatcher to handle non UTF-8 files

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6789dfc68833086d7b52353430f83